### PR TITLE
Allow using this library with only tokio `io-util` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "async-socks5"
 version = "0.6.0"
-authors = ["Arsenii Lyashenko <arsenylyashenko.3@gmail.com>", "Temirkhan Myrzamadi <hirrolot@gmail.com>"]
+authors = [
+    "Arsenii Lyashenko <arsenylyashenko.3@gmail.com>",
+    "Temirkhan Myrzamadi <hirrolot@gmail.com>",
+]
 license = "Apache-2.0 OR MIT"
 description = "An async/.await SOCKS5 implementation"
 repository = "https://github.com/ark0f/async-socks5"
@@ -16,8 +19,12 @@ edition = "2021"
 github-actions = { repository = "https://github.com/ark0f/async-socks5", workflow = "CI" }
 
 [dependencies]
-tokio = { version = "1.0", features = ["net", "io-util"] }
+tokio = { version = "1.0", features = ["io-util"] }
 thiserror = "1.0.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["net", "io-util", "rt", "macros"] }
+
+[features]
+default = ["tokio-net"]
+tokio-net = ["tokio/net"]


### PR DESCRIPTION
Gate usage of tokio `net` module behind `tokio-net` feature (enabled by default).

When using `default-features = false`, we can use the `connect()` function depending only on some tokio io traits.

This PR should have no effect on existing users since the feature gate is enabled by default.
